### PR TITLE
Fix having multiple derives in the same project

### DIFF
--- a/mg-settings-macros/Cargo.toml
+++ b/mg-settings-macros/Cargo.toml
@@ -4,7 +4,7 @@ description = "Help custom derive for mg-settings"
 license = "MIT"
 name = "mg-settings-macros"
 repository = "https://github.com/antoyo/mg-settings"
-version = "0.4.1"
+version = "0.4.2"
 
 [dependencies]
 env_logger = "0.5"

--- a/mg-settings-macros/src/lib.rs
+++ b/mg-settings-macros/src/lib.rs
@@ -51,7 +51,7 @@ fn init_logger() {
     if let Ok(rust_log) = env::var("RUST_LOG") {
         builder.parse(&rust_log);
     }
-    builder.init();
+    builder.try_init();
 }
 
 #[proc_macro_derive(Commands, attributes(completion, count, help, special_command))]


### PR DESCRIPTION
env_logger::Builder::init() panics if it's called twice...